### PR TITLE
Feature: agregar migraciones para usuario, paciente e historias clínicas con auditoría en timestamp

### DIFF
--- a/console/migrations/m250604_052454_create_usuario_table.php
+++ b/console/migrations/m250604_052454_create_usuario_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%usuario}}`.
+ */
+class m250604_052454_create_usuario_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%usuario}}', [
+            'id' => $this->primaryKey(),
+            'username' => $this->string(100)->notNull()->unique(),
+            'password_hash' => $this->string(255)->notNull(),
+            'rol' => "ENUM('admin','doctor','asistente') NOT NULL",
+            'doctor_id' => $this->integer()->defaultValue(null),
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+            'created_by' => $this->integer()->defaultValue(null),
+            'updated_by' => $this->integer()->defaultValue(null),
+        ]);
+
+        $this->createIndex('idx_usuario_username', '{{%usuario}}', 'username');
+        $this->createIndex('idx_usuario_rol', '{{%usuario}}', 'rol');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropTable('{{%usuario}}');
+    }
+}

--- a/console/migrations/m250604_052505_create_paciente_table.php
+++ b/console/migrations/m250604_052505_create_paciente_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%paciente}}`.
+ */
+class m250604_052505_create_paciente_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%paciente}}', [
+            'id' => $this->primaryKey(),
+            'cedula' => $this->string(20)->notNull()->unique(),
+            'nombres' => $this->string(100)->notNull(),
+            'apellidos' => $this->string(100)->notNull(),
+            'fecha_nacimiento' => $this->date()->notNull(),
+            'sexo' => "ENUM('M','F') NOT NULL",
+            'direccion' => $this->string(255)->notNull(),
+            'telefono' => $this->string(50),
+            'estado_civil' => "ENUM('soltero','casado','viudo','divorciado','union libre') DEFAULT 'soltero'",
+            'ocupacion' => $this->string(100),
+            'empresa' => $this->string(100),
+            'aseguradora' => $this->string(100),
+            'grupo_sanguineo' => $this->string(3),
+            'nacionalidad' => $this->string(50),
+            'nivel_instruccion' => $this->string(50),
+            'contacto_emergencia_nombre' => $this->string(100),
+            'contacto_emergencia_telefono' => $this->string(50),
+            'estado' => "ENUM('activo','inactivo') DEFAULT 'activo'",
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+            'created_by' => $this->integer()->notNull(),
+            'updated_by' => $this->integer()->notNull(),
+        ]);
+
+        $this->createIndex('idx_paciente_cedula', '{{%paciente}}', 'cedula');
+        $this->createIndex('idx_paciente_nombres', '{{%paciente}}', 'nombres');
+        $this->createIndex('idx_paciente_apellidos', '{{%paciente}}', 'apellidos');
+        $this->createIndex('idx_paciente_estado', '{{%paciente}}', 'estado');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropTable('{{%paciente}}');
+    }
+}

--- a/console/migrations/m250604_052511_create_historias_clinicas_tableyes.php
+++ b/console/migrations/m250604_052511_create_historias_clinicas_tableyes.php
@@ -1,0 +1,64 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles the creation of table `{{%historias_clinicas}}`.
+ */
+class m250604_052511_create_historias_clinicas_tableyes extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->createTable('{{%historias_clinicas}}', [
+            'id' => $this->primaryKey(),
+            'paciente_id' => $this->integer()->notNull(),
+            'doctor_id' => $this->integer()->notNull(),
+            'fecha' => $this->date()->notNull(),
+            'contenido' => $this->text(),
+            'estado' => "ENUM('activo','eliminado') DEFAULT 'activo'",
+            'created_at' => $this->integer()->notNull(),
+            'updated_at' => $this->integer()->notNull(),
+            'created_by' => $this->integer()->notNull(),
+            'updated_by' => $this->integer()->notNull(),
+        ]);
+
+        // Claves foráneas
+        $this->addForeignKey(
+            'fk_historias_paciente',
+            '{{%historias_clinicas}}',
+            'paciente_id',
+            '{{%paciente}}',
+            'id',
+            'RESTRICT',
+            'CASCADE'
+        );
+
+        $this->addForeignKey(
+            'fk_historias_doctor',
+            '{{%historias_clinicas}}',
+            'doctor_id',
+            '{{%usuario}}',
+            'id',
+            'RESTRICT',
+            'CASCADE'
+        );
+
+        // Índices
+        $this->createIndex('idx_historia_paciente_id', '{{%historias_clinicas}}', 'paciente_id');
+        $this->createIndex('idx_historia_doctor_id', '{{%historias_clinicas}}', 'doctor_id');
+        $this->createIndex('idx_historia_estado', '{{%historias_clinicas}}', 'estado');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropForeignKey('fk_historias_paciente', '{{%historias_clinicas}}');
+        $this->dropForeignKey('fk_historias_doctor', '{{%historias_clinicas}}');
+        $this->dropTable('{{%historias_clinicas}}');
+    }
+}


### PR DESCRIPTION
## 📌 Descripción

Este Pull Request agrega las migraciones iniciales para las tablas principales del proyecto:

✅ `usuario`: tabla para manejar los usuarios del sistema, incluyendo roles y claves foráneas.  
✅ `paciente`: tabla para almacenar la información de los pacientes, incluyendo datos de contacto, grupo sanguíneo y aseguradora.  
✅ `historias_clinicas`: tabla para registrar las historias clínicas de los pacientes, enlazando con el usuario (doctor) y el paciente.

Las migraciones usan **UNIX timestamp** (`INTEGER`) para las columnas de auditoría (`created_at` y `updated_at`), siguiendo el estándar utilizado en la tabla de ejemplo `user` que viene con Yii2.

---

## 🚀 ¿Qué incluye este PR?

- Creación de las tablas:
  - `usuario`
  - `paciente`
  - `historias_clinicas`
- Índices principales para búsquedas eficientes.
- Claves foráneas para integridad referencial.
- Columnas de auditoría (`created_at`, `updated_at`, `created_by`, `updated_by`).

---

## 📋 Cómo probarlo

1. Ejecutar las migraciones:
   ```bash
   php yii migrate
